### PR TITLE
Fix optional parameter before required one

### DIFF
--- a/src/PDFEmbed.hooks.php
+++ b/src/PDFEmbed.hooks.php
@@ -38,7 +38,7 @@ class PDFEmbed
      * @param object    PPFrame object.
      * @return    string    HTML
      */
-    static public function generateTag($file, $args = [], Parser $parser, PPFrame $frame)
+    static public function generateTag($file, $args, Parser $parser, PPFrame $frame)
     {
         $request = RequestContext::getMain()->getRequest();
 


### PR DESCRIPTION
This is deprecated in PHP 8.